### PR TITLE
feature: read upstream from resolvconf file

### DIFF
--- a/freedns/freedns_test.go
+++ b/freedns/freedns_test.go
@@ -1,25 +1,10 @@
 package freedns
 
 import (
-	"github.com/miekg/dns"
 	"testing"
-)
 
-func TestAppendDefaultPort(t *testing.T) {
-	cases := []struct {
-		i string
-		o string
-	}{
-		{"127.0.0.1", "127.0.0.1:53"},
-		{"114.114.114.114:5353", "114.114.114.114:5353"},
-		{"::1", "::1"},
-	}
-	for _, c := range cases {
-		if appendDefaultPort(c.i) != c.o {
-			t.Errorf("Expected: %s", c.o)
-		}
-	}
-}
+	"github.com/miekg/dns"
+)
 
 func TestSmokingNewRunAndShutdown(t *testing.T) {
 	// new the server

--- a/freedns/resolve_test.go
+++ b/freedns/resolve_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_spoofing_proof_resolver_resolve(t *testing.T) {
-	resolver := newSpoofingProofResolver("114.114.114.114:53", "8.8.8.8:53", 1024)
+	resolver := newSpoofingProofResolver(&staticUpstreamProvider{"114.114.114.114:53"}, &staticUpstreamProvider{"8.8.8.8:53"}, 1024)
 
 	tests := []struct {
 		domain           string

--- a/freedns/upstream_provider.go
+++ b/freedns/upstream_provider.go
@@ -1,0 +1,124 @@
+package freedns
+
+import (
+	"os"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/miekg/dns"
+)
+
+type upstreamProvider interface {
+	GetUpstream() string
+}
+
+type staticUpstreamProvider struct {
+	upstream string
+}
+
+func (provider *staticUpstreamProvider) GetUpstream() string {
+	return provider.upstream
+}
+
+type resolvconfUpstreamProvider struct {
+	filename string
+	// keep last valid servers even if file becomes invalid
+	servers      []string
+	serversMutex sync.RWMutex
+}
+
+func (provider *resolvconfUpstreamProvider) GetUpstream() string {
+	provider.serversMutex.RLock()
+	defer provider.serversMutex.RUnlock()
+	// Always use the first one for now
+	return provider.servers[0]
+}
+
+func parseServersFromResolvconf(filename string) ([]string, error) {
+	parsedConfig, err := dns.ClientConfigFromFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	servers := make([]string, 0)
+	for _, addr := range parsedConfig.Servers {
+		if normalized, err := normalizeDnsAddress(addr); err == nil {
+			servers = append(servers, normalized)
+		}
+	}
+
+	if len(servers) == 0 {
+		return nil, Error("No servers found in " + filename)
+	}
+
+	return servers, nil
+}
+
+func newResolvconfUpstreamProvider(filename string) (*resolvconfUpstreamProvider, error) {
+	servers, err := parseServersFromResolvconf(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	provider := &resolvconfUpstreamProvider{
+		filename: filename,
+		servers:  servers,
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := watcher.Add(filename); err != nil {
+		return nil, err
+	}
+	go func() {
+		// TODO: `watcher` will outlive upstream provider
+		// we need to add a Close method to upstreamProvider
+		defer watcher.Close()
+		logger := log.WithField("filename", filename)
+		logger.Info("Start watching")
+		for {
+			select {
+			case _, ok := <-watcher.Events:
+				if !ok {
+					logger.Warn("Watch failed")
+					return
+				}
+			case err, ok := <-watcher.Errors:
+				logger.WithField("error", err).WithField("ok", ok).Warn("Watch failed")
+				return
+			}
+			logger.Info("Reload resolvconf")
+
+			servers, err := parseServersFromResolvconf(filename)
+			if err != nil {
+				logger.WithField("error", err).Warn("Cannot read servers, ignore")
+				continue
+			}
+
+			provider.serversMutex.Lock()
+			provider.servers = servers
+			provider.serversMutex.Unlock()
+		}
+	}()
+
+	return provider, nil
+}
+
+// Create upstream provider based on upstream name
+//
+// Possible name values are:
+// IP address (with optional port) :: use this IP as static upstream
+// Filename :: parse the file as resolv.conf, read upstreams from the file (monitor file change)
+func newUpstreamProvider(name string) (upstreamProvider, error) {
+	if addr, err := normalizeDnsAddress(name); err == nil {
+		return &staticUpstreamProvider{
+			upstream: addr,
+		}, nil
+	}
+	if fileinfo, err := os.Stat(name); err == nil && !fileinfo.IsDir() {
+		return newResolvconfUpstreamProvider(name)
+	}
+	return nil, Error("Invalid upstream name " + name)
+}

--- a/freedns/upstream_provider_test.go
+++ b/freedns/upstream_provider_test.go
@@ -1,0 +1,79 @@
+package freedns
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestInvalidUpstreamProvider(t *testing.T) {
+	cases := []string{
+		"asdfasdf",
+		"/dev/null",
+	}
+	for _, name := range cases {
+		if _, err := newUpstreamProvider(name); err == nil {
+			t.Errorf("Should not create provider for %s", name)
+		}
+	}
+}
+
+func TestStaticUpstreamProvider(t *testing.T) {
+	provider, err := newUpstreamProvider("8.8.4.4")
+	if err != nil || provider == nil {
+		t.Errorf("Cannot create static upstream provider")
+		return
+	}
+	if upstream := provider.GetUpstream(); upstream != "8.8.4.4:53" {
+		t.Errorf("Static upstream provider invalid result %s", upstream)
+	}
+}
+
+func TestResolvconfUpstreamProvider(t *testing.T) {
+	tempfile, err := ioutil.TempFile("", "test_resolvconf")
+	if err != nil {
+		t.Errorf("Cannot create temp file: %s", err.Error())
+		return
+	}
+	filename := tempfile.Name()
+	tempfile.Close()
+
+	WriteContent := func(content string) {
+		tempfile, err := os.Create(filename)
+		if err != nil {
+			t.Errorf("Cannot open temp file: %s", err.Error())
+			return
+		}
+		defer tempfile.Close()
+		tempfile.Write([]byte(content))
+	}
+
+	defer os.Remove(filename)
+
+	WriteContent("nameserver 1.2.3.4\n")
+
+	provider, err := newUpstreamProvider(filename)
+	if err != nil {
+		t.Errorf("Cannot create resolvconf upstream provider for %s: %s", filename, err.Error())
+		return
+	}
+
+	if upstream := provider.GetUpstream(); upstream != "1.2.3.4:53" {
+		t.Errorf("Bad result %s", upstream)
+	}
+
+	WriteContent("nameserver 8.8.8.8\nnameserver8.8.4.4\n")
+	time.Sleep(100 * time.Millisecond)
+	// should be updated
+	if upstream := provider.GetUpstream(); upstream != "8.8.8.8:53" {
+		t.Errorf("Bad result %s", upstream)
+	}
+
+	WriteContent("some invalid content")
+	time.Sleep(100 * time.Millisecond)
+	// should not be updated
+	if upstream := provider.GetUpstream(); upstream != "8.8.8.8:53" {
+		t.Errorf("Bad result %s", upstream)
+	}
+}

--- a/freedns/utils.go
+++ b/freedns/utils.go
@@ -1,0 +1,22 @@
+package freedns
+
+import "net"
+
+// Parse ip with optional port, return normalized ip:port string
+// For ips without port, default 53 port is appended
+func normalizeDnsAddress(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// no port, try parse addr as host with default port
+		host = addr
+		port = "53"
+	} else if host == "" {
+		// for addrs like ":53", use default host
+		host = "0.0.0.0"
+	}
+
+	if net.ParseIP(host) == nil {
+		return "", Error("Invalid IP addr: " + host)
+	}
+	return net.JoinHostPort(host, port), nil
+}

--- a/freedns/utils_test.go
+++ b/freedns/utils_test.go
@@ -1,0 +1,28 @@
+package freedns
+
+import "testing"
+
+func Test_normalizeDnsAddress(t *testing.T) {
+	assertError := func(addr string) {
+		if res, err := normalizeDnsAddress(addr); res != "" || err == nil {
+			t.Errorf("%s should not be normalized as dns address", addr)
+		}
+	}
+	assertResult := func(addr, expected string) {
+		if res, err := normalizeDnsAddress(addr); res != expected || err != nil {
+			t.Errorf("%s should be normalized as %s, got %s (%s)", addr, expected, res, err.Error())
+		}
+	}
+
+	assertError("")
+	assertError("hello world")
+	assertError("123:456")
+	assertError("/hello/world:filename")
+	assertError("1.2.3.4.5")
+
+	assertResult("1.2.3.4", "1.2.3.4:53")
+	assertResult("127.0.0.1:3333", "127.0.0.1:3333")
+	assertResult("::1", "[::1]:53")
+	assertResult("[::]:5300", "[::]:5300")
+	assertResult(":5300", "0.0.0.0:5300")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tuna/freedns-go
 go 1.13
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/louchenyao/golang-cache v0.0.0-20190309153624-1d1c4bb01145
 	github.com/miekg/dns v1.1.27
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/louchenyao/golang-cache v0.0.0-20190309153624-1d1c4bb01145 h1:a6W9GKXRz9iiJxokZ5znNa2S7DhsAfPlj++6dG/1stY=
 github.com/louchenyao/golang-cache v0.0.0-20190309153624-1d1c4bb01145/go.mod h1:qo/Jbijoez5mIuriNYfgydZnCXt7xiP1tS82aoxk6yE=
@@ -27,6 +29,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -18,22 +18,22 @@ func main() {
 	*/
 
 	var (
-		fastDNS  string
-		cleanDNS string
-		listen   string
+		fastUpstream  string
+		cleanUpstream string
+		listen        string
 	)
 
-	flag.StringVar(&fastDNS, "f", "114.114.114.114:53", "The fast/local DNS upstream.")
-	flag.StringVar(&cleanDNS, "c", "8.8.8.8:53", "The clean/remote DNS upstream.")
+	flag.StringVar(&fastUpstream, "f", "114.114.114.114:53", "The fast/local DNS upstream, ip:port or resolv.conf file")
+	flag.StringVar(&cleanUpstream, "c", "8.8.8.8:53", "The clean/remote DNS upstream., ip:port or resolv.conf file")
 	flag.StringVar(&listen, "l", "0.0.0.0:53", "Listening address.")
 
 	flag.Parse()
 
 	s, err := freedns.NewServer(freedns.Config{
-		FastDNS:  fastDNS,
-		CleanDNS: cleanDNS,
-		Listen:   listen,
-		CacheCap: 1024 * 10,
+		FastUpstream:  fastUpstream,
+		CleanUpstream: cleanUpstream,
+		Listen:        listen,
+		CacheCap:      1024 * 10,
 	})
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
如题，upstream可以直接指定一个文件（resolv.conf格式），从中读取upstream server，并且监测文件变动。对笔记本等网络经常变化的环境下非常有用。

代码改动：将upstream改成upstreamProvider类，提供static provider和resolvconf provider